### PR TITLE
Fix Timed flow on streams that haven't started

### DIFF
--- a/src/test/scala/org/apache/pekko/stream/contrib/TimedSpec.scala
+++ b/src/test/scala/org/apache/pekko/stream/contrib/TimedSpec.scala
@@ -32,7 +32,8 @@ class TimedSpec extends BaseStreamSpec {
 
       source.runWith(Sink.ignore)
       (1 until n / measureBetweenEvery).foreach { _ =>
-        testActor.expectMsgType[FiniteDuration]
+        val duration = testActor.expectMsgType[FiniteDuration]
+        assert(duration.toMillis >= 0, s"$duration is not a positive duration")
       }
     }
 
@@ -46,7 +47,8 @@ class TimedSpec extends BaseStreamSpec {
       }
 
       Source(1 to n).timed(_.map(identity), onComplete = printInfo).runWith(Sink.ignore)
-      testActor.expectMsgType[FiniteDuration]
+      val duration = testActor.expectMsgType[FiniteDuration]
+      assert(duration.toMillis >= 0, s"$duration is not a positive duration")
     }
 
   }
@@ -72,6 +74,7 @@ class TimedSpec extends BaseStreamSpec {
 
       val duration = probe.expectMsgType[Duration]
       info(s"Got duration (first): $duration")
+      assert(duration.toMillis >= 0, s"$duration is not a positive duration")
     }
 
     "measure time from start to complete, by wrapping operations" in {
@@ -102,6 +105,7 @@ class TimedSpec extends BaseStreamSpec {
 
       val duration = probe.expectMsgType[Duration]
       info(s"Took: $duration")
+      assert(duration.toMillis >= 0, s"$duration is not a positive duration")
     }
   }
 }

--- a/src/test/scala/org/apache/pekko/stream/contrib/TimedSpec.scala
+++ b/src/test/scala/org/apache/pekko/stream/contrib/TimedSpec.scala
@@ -33,7 +33,7 @@ class TimedSpec extends BaseStreamSpec {
       source.runWith(Sink.ignore)
       (1 until n / measureBetweenEvery).foreach { _ =>
         val duration = testActor.expectMsgType[FiniteDuration]
-        assert(duration.toMillis >= 0, s"$duration is not a positive duration")
+        assert(duration.toNanos > 0, s"$duration is not a positive duration")
       }
     }
 
@@ -48,7 +48,7 @@ class TimedSpec extends BaseStreamSpec {
 
       Source(1 to n).timed(_.map(identity), onComplete = printInfo).runWith(Sink.ignore)
       val duration = testActor.expectMsgType[FiniteDuration]
-      assert(duration.toMillis >= 0, s"$duration is not a positive duration")
+      assert(duration.toNanos > 0, s"$duration is not a positive duration")
     }
 
     "return Duration.Zero if the stream completes without starting" in {
@@ -87,7 +87,7 @@ class TimedSpec extends BaseStreamSpec {
 
       val duration = probe.expectMsgType[Duration]
       info(s"Got duration (first): $duration")
-      assert(duration.toMillis >= 0, s"$duration is not a positive duration")
+      assert(duration.toNanos > 0, s"$duration is not a positive duration")
     }
 
     "measure time from start to complete, by wrapping operations" in {
@@ -118,7 +118,7 @@ class TimedSpec extends BaseStreamSpec {
 
       val duration = probe.expectMsgType[Duration]
       info(s"Took: $duration")
-      assert(duration.toMillis >= 0, s"$duration is not a positive duration")
+      assert(duration.toNanos > 0, s"$duration is not a positive duration")
     }
 
     "return Duration.Zero if the stream completes without starting" in {

--- a/src/test/scala/org/apache/pekko/stream/contrib/TimedSpec.scala
+++ b/src/test/scala/org/apache/pekko/stream/contrib/TimedSpec.scala
@@ -104,7 +104,7 @@ class TimedSpec extends BaseStreamSpec {
         flow.runWith(Source.asSubscriber[Int], Sink.asPublisher[String](false))
 
       val c1 = TestSubscriber.manualProbe[String]()
-      val c2 = flowOut.subscribe(c1)
+      flowOut.subscribe(c1)
 
       val p = Source(0 to 100).runWith(Sink.asPublisher(false))
       p.subscribe(flowIn)
@@ -135,7 +135,7 @@ class TimedSpec extends BaseStreamSpec {
         flow.runWith(Source.asSubscriber[Int], Sink.asPublisher[String](false))
 
       val c1 = TestSubscriber.manualProbe[String]()
-      val c2 = flowOut.subscribe(c1)
+      flowOut.subscribe(c1)
 
       val p = Source.empty[Int].runWith(Sink.asPublisher(false))
       p.subscribe(flowIn)


### PR DESCRIPTION
The `Timed.timed` flow measures the time between the first element and the stream completion.

However, when the stream completes without emitting any event, it would compute `duration = System.nanoTime() - 0`, which was clearly wrong.